### PR TITLE
Add DataFrameMapper feature metadata and y-value support.

### DIFF
--- a/examples/01 Flowers and Forests - A Simple Pipeline.ipynb
+++ b/examples/01 Flowers and Forests - A Simple Pipeline.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import sklearn.datasets\n",
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn_pandas import DataFrameMapper, make_dataframe_pipeline\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.cross_validation import cross_val_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Gather a Tidy Dataframe\n",
+    "----"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sepal length (cm)</th>\n",
+       "      <th>sepal width (cm)</th>\n",
+       "      <th>petal length (cm)</th>\n",
+       "      <th>petal width (cm)</th>\n",
+       "      <th>class</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.1</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.9</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>4.7</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>1.3</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4.6</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
+       "0                5.1               3.5                1.4               0.2   \n",
+       "1                4.9               3.0                1.4               0.2   \n",
+       "2                4.7               3.2                1.3               0.2   \n",
+       "3                4.6               3.1                1.5               0.2   \n",
+       "4                5.0               3.6                1.4               0.2   \n",
+       "\n",
+       "    class  \n",
+       "0  setosa  \n",
+       "1  setosa  \n",
+       "2  setosa  \n",
+       "3  setosa  \n",
+       "4  setosa  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "iris_data = sklearn.datasets.load_iris()\n",
+    "iris = pandas.DataFrame(data = iris_data[\"data\"], columns=iris_data[\"feature_names\"])\n",
+    "iris[\"class\"] = iris_data[\"target_names\"][iris_data[\"target\"]]\n",
+    "\n",
+    "iris.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assemble a Simple Learning Pipeline\n",
+    "--------\n",
+    "\n",
+    "A DataFramePipeline begins with a DataFrameMapper, specify how features **`X`** and targets **`y`** are extracted from an input frame. It ends with an estimator object.\n",
+    "\n",
+    "In this case, extract each available feature without transformation and specify the class label as the target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "forest_pipeline = make_dataframe_pipeline([\n",
+    "        DataFrameMapper(iris_data[\"feature_names\"], \"class\"),\n",
+    "        RandomForestClassifier(n_estimators=200)\n",
+    "    ])\n",
+    "\n",
+    "logistic_pipeline = make_dataframe_pipeline([\n",
+    "        DataFrameMapper(iris_data[\"feature_names\"], \"class\"),\n",
+    "        LogisticRegression()\n",
+    "    ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cross Validate\n",
+    "-----\n",
+    "\n",
+    "Cross validation requires the target **`y`** to perform train-test splits. Use the pipeline's DataFrameMapper to extract the target feature array from input data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>forest</th>\n",
+       "      <th>logistic</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>0.960000</td>\n",
+       "      <td>0.960000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>0.027889</td>\n",
+       "      <td>0.043461</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.933333</td>\n",
+       "      <td>0.900000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>0.933333</td>\n",
+       "      <td>0.933333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>0.966667</td>\n",
+       "      <td>0.966667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>0.966667</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         forest  logistic\n",
+       "count  5.000000  5.000000\n",
+       "mean   0.960000  0.960000\n",
+       "std    0.027889  0.043461\n",
+       "min    0.933333  0.900000\n",
+       "25%    0.933333  0.933333\n",
+       "50%    0.966667  0.966667\n",
+       "75%    0.966667  1.000000\n",
+       "max    1.000000  1.000000"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cross_val_result = pandas.DataFrame.from_dict({\n",
+    "    \"forest\" : cross_val_score(\n",
+    "        estimator = forest_pipeline,\n",
+    "        X = iris, y = forest_pipeline._dataframe_mapper.extract_y(iris),\n",
+    "        cv = 5, scoring=\"accuracy\"),\n",
+    "    \"logistic\" : cross_val_score(\n",
+    "        estimator = logistic_pipeline,\n",
+    "        X = iris, y = logistic_pipeline._dataframe_mapper.extract_y(iris),\n",
+    "        cv = 5, scoring=\"accuracy\")\n",
+    "    })\n",
+    "\n",
+    "cross_val_result.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Extract Feature Metadata\n",
+    "----\n",
+    "\n",
+    "The DataFrameMapper may be used to associate estimator metadata with feature source information. In this case, the `feature_importances_` vector is associated with the source column name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sepal length (cm)    0.111118\n",
+       "sepal width (cm)     0.028009\n",
+       "petal length (cm)    0.455807\n",
+       "petal width (cm)     0.405066\n",
+       "Name: feature_importances, dtype: float64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "forest_pipeline.fit(iris)\n",
+    "pandas.Series(\n",
+    "    data = forest_pipeline._final_estimator.feature_importances_,\n",
+    "    index = forest_pipeline._dataframe_mapper.X_columns_,\n",
+    "    name=\"feature_importances\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/sklearn_pandas/__init__.py
+++ b/sklearn_pandas/__init__.py
@@ -2,3 +2,4 @@ __version__ = '1.1.0'
 
 from .dataframe_mapper import DataFrameMapper  # NOQA
 from .cross_validation import cross_val_score, GridSearchCV, RandomizedSearchCV  # NOQA
+from .dataframe_pipeline import DataFramePipeline, make_dataframe_pipeline

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -103,6 +103,14 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
 
         return t
 
+    def extract_Xy(self, X, y=None):
+        """Extract X and y values for pipeline from inputs 'X' and 'y'."""
+        return self.extract_X(X), self.extract_y(X, y)
+
+    def extract_X(self, X):
+        """Extract X values for pipeline, equivalent to self.transform."""
+        return self.transform(X)
+
     def extract_y(self, X, y=None):
         """Extract y values for pipeline from input 'y' or 'X'.
 

--- a/sklearn_pandas/dataframe_pipeline.py
+++ b/sklearn_pandas/dataframe_pipeline.py
@@ -1,0 +1,148 @@
+import six
+from sklearn.pipeline import _name_estimators, Pipeline
+from sklearn.utils.metaestimators import if_delegate_has_method
+
+from sklearn_pandas.dataframe_mapper import DataFrameMapper
+
+class DataFramePipeline(Pipeline):
+    """Pipeline of transforms with a final estimator supporting DataFrame input.
+    
+    Sequentially applies a list of transforms and a final estimator, extracting
+    'X' and 'y' data for the pipeline via an initial DataFrameMapper. The first
+    step of the pipeline must be a DataFrameMapper. Intermediate steps of the
+    pipeline must be 'transforms' implementing the 'fit' and 'transform' methods.
+    The final estimator only needs to implement fit.
+    
+    Parameters
+    ----------
+    steps : list
+        List of (name, transform) tuples (implementing fit/transform) that are
+        chained, in the order in which they are chained, with the last object
+        an estimator.
+    """
+    
+    def __init__(self, steps):
+        Pipeline.__init__(self, steps)
+        
+        if not isinstance(self._dataframe_mapper, DataFrameMapper):
+            raise TypeError(
+                "First step of a DataFramePipeline must be a DataFrameMapper, "
+                "'%s' (type %s) is not." %
+                (self._dataframe_mapper, type(self._dataframe_mapper))
+            )
+            
+    @property
+    def _dataframe_mapper(self):
+        """Return DataFrameMapper at head of pipeline."""
+        return self.steps[0][1]
+    
+    @property
+    def _dataframe_mapper_name(self):
+        """Return name of DataFrameMapper at head of pipeline."""
+        return self.steps[0][0]
+    
+    def _pre_transform(self, X, y=None, **fit_params):
+        fit_params_steps = dict((step, {}) for step, _ in self.steps)
+        for pname, pval in six.iteritems(fit_params):
+            step, param = pname.split('__', 1)
+            fit_params_steps[step][param] = pval
+            
+        Xt = self._dataframe_mapper.fit_transform(
+            X, y, **fit_params_steps[self._dataframe_mapper_name])
+        yt = self._dataframe_mapper.extract_y(X, y)
+        
+        for name, transform in self.steps[1:-1]:
+            if hasattr(transform, "fit_transform"):
+                Xt = transform.fit_transform(Xt, y, **fit_params_steps[name])
+            else:
+                Xt = transform.fit(Xt, y, **fit_params_steps[name]) \
+                              .transform(Xt)
+                    
+        return Xt, yt, fit_params_steps[self.steps[-1][0]]
+    
+    def fit(self, X, y=None, **fit_params):
+        """Fit all the transforms one after the other and transform the
+        data, then fit the transformed data using the final estimator.
+
+        Parameters
+        ----------
+        X : (DataFrame)
+            Training data. Must fulfill input requirements of first step of the
+            pipeline.
+        y : (DataFrame or Series), default=None
+            Training targets. Must fulfill label requirements for all steps of
+            the pipeline. Training target are extracted via mapper from 'X' if
+            'y' is None.
+        """
+        Xt, yt, fit_params = self._pre_transform(X, y, **fit_params)
+        self.steps[-1][-1].fit(Xt, yt, **fit_params)
+        return self
+    
+    def fit_transform(self, X, y=None, **fit_params):
+        """Fit all the transforms one after the other and transform the
+        data, then use fit_transform on transformed data using the final
+        estimator.
+
+        Parameters
+        ----------
+        X : (DataFrame)
+            Training data. Must fulfill input requirements of first step of the
+            pipeline.
+        y : (DataFrame or Series), default=None
+            Training targets. Must fulfill label requirements for all steps of
+            the pipeline. Training target are extracted via mapper from 'X' if
+            'y' is None.
+        """
+        Xt, yt, fit_params = self._pre_transform(X, y, **fit_params)
+        if hasattr(self.steps[-1][-1], 'fit_transform'):
+            return self.steps[-1][-1].fit_transform(Xt, yt, **fit_params)
+        else:
+            return self.steps[-1][-1].fit(Xt, yt, **fit_params).transform(Xt)
+        
+    @if_delegate_has_method(delegate='_final_estimator')
+    def fit_predict(self, X, y=None, **fit_params):
+        """Applies fit_predict of last step in pipeline after transforms.
+
+        Applies fit_transforms of a pipeline to the data, followed by the
+        fit_predict method of the final estimator in the pipeline. Valid
+        only if the final estimator implements fit_predict.
+
+        Parameters
+        ----------
+        X : (DataFrame)
+            Training data. Must fulfill input requirements of first step of the
+            pipeline.
+        y : (DataFrame or Series), default=None
+            Training targets. Must fulfill label requirements for all steps of
+            the pipeline. Training target are extracted via mapper from 'X' if
+            'y' is None.
+        """
+        Xt, yt, fit_params = self._pre_transform(X, y, **fit_params)
+        return self.steps[-1][-1].fit_predict(Xt, yt, **fit_params)
+    
+    @if_delegate_has_method(delegate='_final_estimator')
+    def score(self, X, y=None):
+        """Applies transforms to the data, and the score method of the
+        final estimator. Valid only if the final estimator implements
+        score.
+
+        Parameters
+        ----------
+        X : (DataFrame)
+            Training data. Must fulfill input requirements of first step of the
+            pipeline.
+        y : (DataFrame or Series), default=None
+            Training targets. Must fulfill label requirements for all steps of
+            the pipeline. Training target are extracted via mapper from 'X' if
+            'y' is None.
+        """
+        Xt = X
+        for name, transform in self.steps[:-1]:
+            Xt = transform.transform(Xt)
+            
+        yt = self._dataframe_mapper.extract_y(X, y)
+        return self.steps[-1][-1].score(Xt, yt)
+
+def make_dataframe_pipeline(steps):
+    """Construct a DataFramePipeline from the given estimators."""
+    return DataFramePipeline(_name_estimators(steps))


### PR DESCRIPTION
This pull request:
- Enhances `DataFrameMapper` object with (optional) support for y-value extraction from input frames in `fit*` methods. Ref discussion in #41. @naught101 @dukebody 
- Adds `features`->`X` metadata properties, to support association of estimator metadata to source columns. Ref #13. @sveitser @dukebody 
- Adds a `Pipeline` subclass, `DataFramePipeline`, to support transparent extraction of `y` values during fitting via an input `DataFrameMapper`.

[Example Notebook](https://github.com/asford/sklearn-pandas/blob/master/examples/01%20Flowers%20and%20Forests%20-%20A%20Simple%20Pipeline.ipynb)

I'm absolutely open to code-review and discussion of the proposed interfaces before merging.
## TODO
- [ ] Add test coverage for added features.
- [ ] Clarify y-value extraction semantics with respect to cases where the `y_feature` column may be present in both input `X` and `y` frame inputs. 
- [ ] Clarify acceptable `y` inputs. `Series` & `DataFrame` support?
- [ ] Move `_dataframe_mapper` and `_final_estimator` properties in `DataFramePipeline` to public properties?
- [ ] Add helper function to support passing DataFramePipelines into sklearn cross-validation functions with extracted `X` and `y` values?
