### PR TITLE
Fix for transformed names when number of column is 1

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
-
+import warnings
 from .cross_validation import DataWrapper
 from .pipeline import make_transformer_pipeline, _call_fit, TransformerPipeline
 
@@ -176,11 +176,6 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         y       the target vector relative to X, optional
 
         """
-        # if isinstance(self.features_def, list):
-        #     self.features = [_build_feature(*f) for f in self.features_def]
-        # else:
-        #     self.features = self.features_def
-
         if isinstance(self.features, list):
             self.built_features = [_build_feature(*f) for f in self.features]
         else:
@@ -240,7 +235,21 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             else:
                 return [name + '_' + str(o) for o in range(num_cols)]
         else:
-            return [name]
+            feature_name = _get_feature_names(transformer)
+            if alias:
+                return [alias]
+            elif feature_name is not None:
+                if isinstance(feature_name, str):
+                    return [feature_name]
+                elif isinstance(feature_name, list) and len(feature_name) == 1:
+                    return feature_name
+                else:
+                    warnings.warn(
+                        "Expecting feature name to be either a string or list "
+                        "of length 1 but found: {}".format(str(feature_name)))
+                    return [name]
+            else:
+                return [name]
 
     def transform(self, X):
         """

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -236,18 +236,21 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                 return [name + '_' + str(o) for o in range(num_cols)]
         else:
             feature_name = _get_feature_names(transformer)
-            if alias:
-                return [alias]
-            elif feature_name is not None:
+
+            if feature_name is not None:
+                def _name(x):
+                    return alias + '_' + x if alias else x
                 if isinstance(feature_name, str):
-                    return [feature_name]
+                    return [_name(f) for f in feature_name]
                 elif isinstance(feature_name, list) and len(feature_name) == 1:
-                    return feature_name
+                    return [_name(f) for f in feature_name]
                 else:
                     warnings.warn(
                         "Expecting feature name to be either a string or list "
                         "of length 1 but found: {}".format(str(feature_name)))
                     return [name]
+            elif alias:
+                return [alias]
             else:
                 return [name]
 

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -127,6 +127,22 @@ def test_single_column_transformed_name(simple_dataframe):
     assert mapper.transformed_names_ == ['new_a']
 
 
+def test_single_dictionary_transformed_name(simple_dataframe):
+    df = pd.DataFrame(
+        [[{'a': 1}], [{'a': 3}]],
+        columns=['colA']
+    )
+
+    outdf = DataFrameMapper(
+        [('colA', DictVectorizer(), {'alias': 'colA'})],
+        df_out=True,
+        default=False
+    ).fit_transform(df)
+
+    columns = sorted(list(outdf.columns))
+    assert columns[0] == 'colA_a'
+
+
 def test_transformed_names_binarizer(complex_dataframe):
     """
     Get transformed names of features in `transformed_names` attribute

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -117,6 +117,16 @@ def test_transformed_names_simple(simple_dataframe):
     assert mapper.transformed_names_ == ['a']
 
 
+def test_single_column_transformed_name(simple_dataframe):
+    """
+    Test alias for a transformation that generates a single column
+    """
+    df = simple_dataframe
+    mapper = DataFrameMapper([('a', None, {'alias': 'new_a'})])
+    mapper.fit_transform(df)
+    assert mapper.transformed_names_ == ['new_a']
+
+
 def test_transformed_names_binarizer(complex_dataframe):
     """
     Get transformed names of features in `transformed_names` attribute


### PR DESCRIPTION
The logic for generating transformed name is very different when there is one column as compared to when there are many columns. This pull request applies the same logic when the number of columns is one. 