### PR TITLE
DataFrameMapper.inverse_transform() for simple transformations

### DIFF
--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -19,7 +19,7 @@ from sklearn.svm import SVC
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.preprocessing import (
-    Imputer, StandardScaler, OneHotEncoder, LabelBinarizer)
+    Imputer, StandardScaler, OneHotEncoder, LabelBinarizer, LabelEncoder)
 from sklearn.feature_selection import SelectKBest, chi2
 from sklearn.base import BaseEstimator, TransformerMixin
 import sklearn.decomposition
@@ -829,3 +829,34 @@ def test_direct_cross_validation(iris_dataframe):
     scores = sklearn_cv_score(pipeline, data, labels)
     assert scores.mean() > 0.96
     assert (scores.std() * 2) < 0.04
+
+
+def test_inverse_transform_simple():
+    df = pd.DataFrame({'colA': list('ynyyn'), 'colB': list('abcab')})
+    mapper = DataFrameMapper([
+        ('colA', LabelEncoder()),
+        ('colB', LabelEncoder()),
+    ])
+
+    transformed = mapper.fit_transform(df)
+    restored = mapper.inverse_transform(transformed)
+
+    assert isinstance(restored, pd.DataFrame)
+    assert restored.equals(df)
+
+
+def test_inverse_transform_multicolumn():
+    df = pd.DataFrame({'colA': list('ynyyn'),
+                       'colB': list('abcab'),
+                       'colC': list('sttts')})
+    mapper = DataFrameMapper([
+        ('colA', LabelEncoder()),
+        ('colB', LabelBinarizer()),
+        ('colC', LabelEncoder()),
+    ])
+
+    transformed = mapper.fit_transform(df)
+    restored = mapper.inverse_transform(transformed)
+
+    assert isinstance(restored, pd.DataFrame)
+    assert restored.equals(df)


### PR DESCRIPTION
I've added an `inverse_transform()` method to the `DataFrameMapper` that works for simple transformations.
I've included tests using the `LabelEncoder` and `LabelBinarizer`, which are passed.

This still fails for more complicated transformations such as `Pipeline`s. I hope it's a useful start at least.