### PR TITLE
Python 3.6, numpy 1.14 and some fix in tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Now that the transformation is trained, we confirm that it works on new data::
 
     >>> sample = pd.DataFrame({'pet': ['cat'], 'children': [5.]})
     >>> np.round(mapper.transform(sample), 2)
-    array([[ 1.  ,  0.  ,  0.  ,  1.04]])
+    array([[1.  , 0.  , 0.  , 1.04]])
 
 
 Output features names
@@ -251,14 +251,14 @@ Only columns that are listed in the DataFrameMapper are kept. To keep a column b
     ...     ('children', None)
     ... ])
     >>> np.round(mapper3.fit_transform(data.copy()))
-    array([[ 1.,  0.,  0.,  4.],
-           [ 0.,  1.,  0.,  6.],
-           [ 0.,  1.,  0.,  3.],
-           [ 0.,  0.,  1.,  3.],
-           [ 1.,  0.,  0.,  2.],
-           [ 0.,  1.,  0.,  3.],
-           [ 1.,  0.,  0.,  5.],
-           [ 0.,  0.,  1.,  4.]])
+    array([[1., 0., 0., 4.],
+           [0., 1., 0., 6.],
+           [0., 1., 0., 3.],
+           [0., 0., 1., 3.],
+           [1., 0., 0., 2.],
+           [0., 1., 0., 3.],
+           [1., 0., 0., 5.],
+           [0., 0., 1., 4.]])
 
 Applying a default transformer
 ******************************
@@ -329,11 +329,11 @@ Then the following code could be used to override default imputing strategy:
     ...     'col3': [0, 0, 0, None, None]
     ... })
     >>> mapper6.fit_transform(data6)
-    array([[ 1.,  1.,  0.],
-           [ 1.,  0.,  0.],
-           [ 1.,  1.,  0.],
-           [ 2.,  1.,  0.],
-           [ 3.,  1.,  0.]])
+    array([[1., 1., 0.],
+           [1., 0., 0.],
+           [1., 1., 0.],
+           [2., 1., 0.],
+           [3., 1., 0.]])
 
 
 Feature selection and other supervised transformations
@@ -344,14 +344,14 @@ Feature selection and other supervised transformations
     >>> from sklearn.feature_selection import SelectKBest, chi2
     >>> mapper_fs = DataFrameMapper([(['children','salary'], SelectKBest(chi2, k=1))])
     >>> mapper_fs.fit_transform(data[['children','salary']], data['pet'])
-    array([[ 90.],
-           [ 24.],
-           [ 44.],
-           [ 27.],
-           [ 32.],
-           [ 59.],
-           [ 36.],
-           [ 27.]])
+    array([[90.],
+           [24.],
+           [44.],
+           [27.],
+           [32.],
+           [59.],
+           [36.],
+           [27.]])
 
 Working with sparse features
 ****************************

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Normally you'll read the data from a file, but for demonstration purposes we'll 
 
     >>> data = pd.DataFrame({'pet':      ['cat', 'dog', 'dog', 'fish', 'cat', 'dog', 'cat', 'fish'],
     ...                      'children': [4., 6, 3, 3, 2, 3, 5, 4],
-    ...                      'salary':   [90, 24, 44, 27, 32, 59, 36, 27]})
+    ...                      'salary':   [90., 24, 44, 27, 32, 59, 36, 27]})
 
 Transformation Mapping
 ----------------------

--- a/tests/test_categorical_imputer.py
+++ b/tests/test_categorical_imputer.py
@@ -29,7 +29,7 @@ def test_unit(input_type, none_value):
 
     Xt = CategoricalImputer().fit_transform(X)
 
-    assert (np.asarray(X) == np.asarray(Xc)).all()
+    assert pd.core.common.array_equivalent(np.asarray(X), np.asarray(Xc))
     assert isinstance(Xt, np.ndarray)
     assert (Xt == ['a', 'b', 'b', 'b']).all()
 
@@ -151,7 +151,7 @@ def test_custom_replacement(replacement_value, input_type):
         replacement=replacement_value
     ).fit_transform(X)
 
-    assert (np.asarray(X) == np.asarray(Xc)).all()
+    assert pd.core.common.array_equivalent(np.asarray(X), np.asarray(Xc))
     assert isinstance(Xt, np.ndarray)
     assert (Xt == ['a', replacement_value, 'b', 'b']).all()
 

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -625,7 +625,8 @@ def test_list_transformers():
     Specifying a list of transformers applies them sequentially to the
     selected column.
     """
-    dataframe = pd.DataFrame({"a": [1, np.nan, 3], "b": [1, 5, 7]})
+    dataframe = pd.DataFrame({"a": [1, np.nan, 3], "b": [1, 5, 7]},
+                             dtype=np.float64)
 
     mapper = DataFrameMapper([
         (["a"], [Imputer(), StandardScaler()]),

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     setuptools==39.0
     wheel==0.24.0
     flake8==2.4.1
-    numpy==1.11.3
+    numpy==1.14.3
     scipy==0.18.1
     pandas==0.19.2
     sklearn17: scikit-learn==0.17.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = {py27,py35}-sklearn{17,18}
+envlist = {py27,py36}-sklearn{17,18}
 
 [testenv]
 deps =
     pytest==3.2.1
-    setuptools==16.0
+    setuptools==39.0
     wheel==0.24.0
     flake8==2.4.1
     numpy==1.11.3


### PR DESCRIPTION
Hi, 
In this PR I've updated the python version used to run tests from 3.5 to 3.6 because is the last python 3 release.

Apart from that, I've updated Numpy to the last version and fixed some issues in tests regarding this update (With the previous version of Numpy this issues were already warned as Deprecated.)

I forced some dtypes in tests and readme to avoid convertion type warnings from sklearn transformers.