### PR TITLE
Last libraries versions

### DIFF
--- a/sklearn_pandas/categorical_imputer.py
+++ b/sklearn_pandas/categorical_imputer.py
@@ -100,6 +100,8 @@ class CategoricalImputer(BaseEstimator, TransformerMixin):
         elif self.strategy == 'fixed_value':
             modes = np.array([self.replacement])
         if modes.shape[0] == 0:
+            raise ValueError('Data is empty or all values are null')
+        elif modes.shape[0] > 1:
             raise ValueError('No value is repeated more than '
                              'once in the column')
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-sklearn{17,18}
+envlist = {py27,py36}-sklearn{17,18,19}-pandas{19,22}
 
 [testenv]
 deps =
@@ -9,9 +9,11 @@ deps =
     flake8==2.4.1
     numpy==1.14.3
     scipy==0.18.1
-    pandas==0.19.2
+    pandas19: pandas==0.19.2
+    pandas22: pandas==0.22.0
     sklearn17: scikit-learn==0.17.1
     sklearn18: scikit-learn==0.18.1
+    sklearn19: scikit-learn==0.19.1
     py27: mock==1.3.0
 
 commands =


### PR DESCRIPTION
I've updated pandas and scikit learn to newest versions.

There is a minor fix in Categorical imputer in order to mantain the same behavior with pandas 0.22.

I've mention this things in #155 