### PR TITLE
Avoid casting dtypes to speedup

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -37,6 +37,13 @@ def _get_feature_names(estimator):
         return estimator.get_feature_names()
     return None
 
+def _handle_feature(fea):
+    """
+    Convert 1-dimensional arrays to 2-dimensional column vectors
+    """
+    if fea.ndim == 1:
+        fea = np.array(fea).reshape((-1, 1))
+    return fea
 
 @contextlib.contextmanager
 def add_column_names_to_exception(column_names):
@@ -179,15 +186,6 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         else:
             return t.values
 
-    def _handle_feature(self, fea):
-        """
-        Convert 1-dimensional arrays to 2-dimensional column vectors
-        """
-        if fea.ndim == 1:
-            fea = np.array(fea).reshape((-1, 1))
-
-        return fea
-
     def fit(self, X, y=None):
         """
         Fit a transformation from the pipeline
@@ -289,7 +287,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             if transformers is not None:
                 with add_column_names_to_exception(columns):
                     Xt = transformers.transform(Xt)
-            extracted.append(self._handle_feature(Xt))
+            extracted.append(_handle_feature(Xt))
 
             alias = options.get('alias')
             self.transformed_names_ += self.get_names(
@@ -308,7 +306,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                 # if not applying a default transformer,
                 # keep column names unmodified
                 self.transformed_names_ += unsel_cols
-            extracted.append(self._handle_feature(Xt))
+            extracted.append(_handle_feature(Xt))
 
         # combine the feature outputs into one array.
         # at this point we lose track of which features

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -37,6 +37,7 @@ def _get_feature_names(estimator):
         return estimator.get_feature_names()
     return None
 
+
 def _handle_feature(fea):
     """
     Convert 1-dimensional arrays to 2-dimensional column vectors
@@ -44,6 +45,7 @@ def _handle_feature(fea):
     if fea.ndim == 1:
         fea = np.array(fea).reshape((-1, 1))
     return fea
+
 
 @contextlib.contextmanager
 def add_column_names_to_exception(column_names):

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -1,13 +1,13 @@
-import sys
 import contextlib
+import sys
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from .cross_validation import DataWrapper
-from .pipeline import make_transformer_pipeline, _call_fit, TransformerPipeline
+from .pipeline import TransformerPipeline, _call_fit, make_transformer_pipeline
 
 PY3 = sys.version_info[0] == 3
 if PY3:
@@ -178,7 +178,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             return t
         else:
             return t.values
-    
+
     def _handle_feature(self, fea):
         """
         Convert 1-dimensional arrays to 2-dimensional column vectors
@@ -186,8 +186,8 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         if fea.ndim == 1:
             fea = np.array(fea).reshape((-1, 1))
 
-        return fea    
-    
+        return fea
+
     def fit(self, X, y=None):
         """
         Fit a transformation from the pipeline
@@ -317,7 +317,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         columns = []
         if self.df_out:  # if output dataframe
             for features in extracted:
-                columns += np.hsplit(features,features.shape[1])
+                columns += np.hsplit(features, features.shape[1])
             columns = [col.ravel() for col in columns]
             stacked = pd.DataFrame(
                 dict(zip(self.transformed_names_, columns)),
@@ -334,5 +334,5 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                     stacked = stacked.toarray()
             else:
                 stacked = np.hstack(extracted)
-                
+
         return stacked


### PR DESCRIPTION
Casting column dtypes from 'object' to 'numeric' (eg. float64) is an extremely expensive operation. Based on my testing, it can slow down the whole `transform()` method by more than 15x.

Prior to this pull request, if any output feature in `extracted` is of 'object' dtype, `stacked=np.hstack(extracted)` will force the whole `stacked` output to have 'object' dtype because a np.ndarray must have homogeneous dtypes. 

This patch explicitly avoid this problem by rewriting the column concatenation part for the case when df_out = True. Specifically, I changed `stacked = np.vstack(extracted)` to pd.concate of columns so that the columns preserve their original dtypes (pd.DataFrame can hold heterogeneous-dtypes columns)

After this change, the `transform` method speeds up by more than 15x for cases when their are object dtypes.