### PR TITLE
Better treatment of unicode feature names in `get_names`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -411,6 +411,7 @@ Changelog
 
 Development
 ******************
+* Fix issues with unicode names in ``get_names`` (#160).
 * Update to build using ``numpy==1.14`` and ``python==3.6`` (#154).
 * Add ``strategy`` and ``replacement`` parameters to ``CategoricalImputer`` to allow imputing
   with values other than the mode (#144).
@@ -495,6 +496,7 @@ Other contributors:
 
 * Ariel Rossanigo (@arielrossanigo)
 * Arnau Gil Amat (@arnau126)
+* Assaf Ben-David (@AssafBenDavid)
 * Cal Paterson (@calpaterson)
 * @defvorfu
 * Gustavo Sena Mafra (@gsmafra)

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -253,7 +253,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
             else:
                 names = _get_feature_names(transformer)
             if names is not None and len(names) == num_cols:
-                return [name + '_' + str(o) for o in names]
+                return ['%s_%s' % (name, o) for o in names]
             # otherwise, return name concatenated with '_1', '_2', etc.
             else:
                 return [name + '_' + str(o) for o in range(num_cols)]

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -1,3 +1,5 @@
+# -*- coding: utf8 -*-
+
 import pytest
 from pkg_resources import parse_version
 
@@ -126,6 +128,14 @@ def test_transformed_names_binarizer(complex_dataframe):
     mapper = DataFrameMapper([('target', LabelBinarizer())])
     mapper.fit_transform(df)
     assert mapper.transformed_names_ == ['target_a', 'target_b', 'target_c']
+
+
+def test_transformed_names_binarizer_unicode():
+    df = pd.DataFrame({'target': [u'ñ', u'á', u'é']})
+    mapper = DataFrameMapper([('target', LabelBinarizer())])
+    mapper.fit_transform(df)
+    expected_names = {u'target_ñ', u'target_á', u'target_é'}
+    assert set(mapper.transformed_names_) == expected_names
 
 
 def test_transformed_names_transformers_list(complex_dataframe):


### PR DESCRIPTION
This solves issue #160.

Rebased on master to get rid of unrelated test failures, and add test for new functionality.