### PR TITLE
Fix for DataFrames with MultiIndex columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 build/
 dist/
 .cache/
+.idea/
+.pytest_cache/

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -233,7 +233,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         if alias is not None:
             name = alias
         elif isinstance(columns, list):
-            name = '_'.join(columns)
+            name = '_'.join(map(str, columns))
         else:
             name = columns
         num_cols = x.shape[1] if len(x.shape) > 1 else 1

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -259,7 +259,7 @@ def test_complex_df(complex_dataframe):
 
 def test_multiindex_df(multiindex_dataframe_incomplete):
     """
-    Get a dataframe from a multiindex dataframe
+    Get a dataframe from a multiindex dataframe with missing data
     """
     df = multiindex_dataframe_incomplete
     mapper = DataFrameMapper([([c], Imputer()) for c in df.columns],

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -119,15 +119,15 @@ def multiindex_dataframe():
 
 
 @pytest.fixture
-def multiindex_dataframe_with_holes(multiindex_dataframe):
+def multiindex_dataframe_incomplete(multiindex_dataframe):
     """Example MultiIndex DataFrame with missing entries
     """
     df = multiindex_dataframe
-    indices_to_delete = np.zeros(df.size)
-    indices_to_delete[:20] = 1
-    np.random.shuffle(indices_to_delete)
-    mask = indices_to_delete.reshape(df.shape).astype(bool)
-    df[mask] = np.nan
+    mask_array = np.zeros(df.size)
+    mask_array[:20] = 1
+    np.random.shuffle(mask_array)
+    mask = mask_array.reshape(df.shape).astype(bool)
+    df.mask(mask, inplace=True)
     return df
 
 
@@ -257,16 +257,15 @@ def test_complex_df(complex_dataframe):
         assert len(transformed[c]) == len(df[c])
 
 
-def test_multiindex_df(multiindex_dataframe_with_holes):
+def test_multiindex_df(multiindex_dataframe_incomplete):
     """
     Get a dataframe from a multiindex dataframe
     """
-    df = multiindex_dataframe_with_holes
-    print(df)
+    df = multiindex_dataframe_incomplete
     mapper = DataFrameMapper([([c], Imputer()) for c in df.columns],
                              df_out=True)
     transformed = mapper.fit_transform(df)
-    assert len(transformed) == len(multiindex_dataframe_with_holes)
+    assert len(transformed) == len(multiindex_dataframe_incomplete)
     for c in df.columns:
         assert len(transformed[str(c)]) == len(df[c])
     assert True

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -257,6 +257,20 @@ def test_complex_df(complex_dataframe):
         assert len(transformed[c]) == len(df[c])
 
 
+def test_numeric_column_names(complex_dataframe):
+    """
+    Get a dataframe from a complex mapped dataframe with numeric column names
+    """
+    df = complex_dataframe
+    df.columns = [0, 1, 2]
+    mapper = DataFrameMapper(
+        [(0, None), (1, None), (2, None)], df_out=True)
+    transformed = mapper.fit_transform(df)
+    assert len(transformed) == len(complex_dataframe)
+    for c in df.columns:
+        assert len(transformed[c]) == len(df[c])
+
+
 def test_multiindex_df(multiindex_dataframe_incomplete):
     """
     Get a dataframe from a multiindex dataframe with missing data
@@ -268,7 +282,6 @@ def test_multiindex_df(multiindex_dataframe_incomplete):
     assert len(transformed) == len(multiindex_dataframe_incomplete)
     for c in df.columns:
         assert len(transformed[str(c)]) == len(df[c])
-    assert True
 
 
 def test_binarizer_df():

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = {py27,py36}-sklearn{17,18,19}-pandas{19,22}
+envlist = {py27,py36}-sklearn{17,18,19}-pandas{19,22,23}
 
 [testenv]
 deps =
-    pytest==3.2.1
+    pytest==3.7.0
     setuptools==39.0
     wheel==0.24.0
     flake8==2.4.1
-    numpy==1.14.3
+    numpy==1.15.0
     scipy==0.18.1
     pandas19: pandas==0.19.2
     pandas22: pandas==0.22.0
+    pandas23: pandas==0.23.3
     sklearn17: scikit-learn==0.17.1
     sklearn18: scikit-learn==0.18.1
     sklearn19: scikit-learn==0.19.1
@@ -18,4 +19,4 @@ deps =
 
 commands =
     flake8 --exclude build
-    py.test README.rst tests
+    py.test README.rst tests -s

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
-envlist = {py27,py36}-sklearn{17,18,19}-pandas{19,22,23}
+envlist = {py27,py36}-sklearn{17,18,19}-pandas{19,22}
 
 [testenv]
 deps =
-    pytest==3.7.0
+    pytest==3.2.1
     setuptools==39.0
     wheel==0.24.0
     flake8==2.4.1
-    numpy==1.15.0
+    numpy==1.14.3
     scipy==0.18.1
     pandas19: pandas==0.19.2
     pandas22: pandas==0.22.0
-    pandas23: pandas==0.23.3
     sklearn17: scikit-learn==0.17.1
     sklearn18: scikit-learn==0.18.1
     sklearn19: scikit-learn==0.19.1
@@ -19,4 +18,4 @@ deps =
 
 commands =
     flake8 --exclude build
-    py.test README.rst tests -s
+    py.test README.rst tests


### PR DESCRIPTION
Calling ```fit_transform()``` on a ```DataFrameMapper``` for DataFrames with a multi-level column index often throws the following error:
```TypeError: sequence item 0: expected str instance, tuple found```
I fixed this by mapping the column-name tuples to ```str```. This change also fixes the related #143.

Along with this change I have created a test and some fixtures to work with MultiIndex-column DataFrames. Tox tests pass for all supplied virtualenv configurations, but fail in an unrelated place for the latest pandas version (I believe this is being fixed elsewhere).

A minor issue that still remains: the column names of the transformed DataFrame are no longer the same as in the original DataFrame because of the tuple to string conversion. The error fix had a higher priority in my own use case, but I am still thinking of a way in which the names are kept the same in cases where it's possible without breaking other cases (i.e. a simple ```eval``` won't cut it).