### PR TITLE
Making DataFrameMapper compatible with GridSearchCV

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -39,6 +39,12 @@ def _build_feature(columns, transformers, options={}):
     return (columns, _build_transformer(transformers), options)
 
 
+def _build_feature_name(values):
+    if isinstance(values, list):
+        values = '-'.join([str(value) for value in values])
+    return values
+
+
 def _get_feature_names(estimator):
     """
     Attempt to extract feature names based on a given estimator
@@ -420,7 +426,11 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         return out
 
     def set_params(self, **params):
-        features = dict(self.features)
+        features = {}
+        for column_names, transformers in self.features:
+            key = _build_feature_name(column_names)
+            features[key] = transformers
+
         assignment = defaultdict(dict)
 
         for key, value in params.items():
@@ -442,5 +452,3 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
 
         for instance in transformers_instances:
             instance.set_params(**assignment[id(instance)])
-
-


### PR DESCRIPTION
In this PR, an attempt to implement the proposal from issue #159 is made. The idea is to write custom `get_params` and `set_params` methods that are compatible with `scikit-learn` grid search objects.

The following snippet shows features supported:
```python
transformer = StandardScaler()
mapper = DataFrameMapper([
    (['colA'], StandardScaler()),
    (['colB'], StandardScaler()),
    ('colC', [StandardScaler(), FunctionTransformer()]
])
pipeline = Pipeline([
    ('mapper', mapper),
    ('classifier', SVC(kernel='linear'))
])

# 1. the pipeline parameters include parameters of the nested transformers
parameters = pipeline.get_params()
assert 'mapper__colA__with_mean' in parameters
assert 'mapper__colA__with_std' in parameters
assert 'mapper__colB__with_mean' in parameters
assert 'mapper__colB__with_std' in parameters

# 2. the parameters of nested transformers can be set from the outside
pipeline.set_params(
    mapper__colA__with_mean=True,
    mapper__colB__with_std=False
)

# 3. getting parameters from list of transformers
assert 'mapper__colC__standardscaler__with_mean' in parameters
assert 'mapper__colC__functiontransformer__func' in parameters

# 4. setting parameters to list of transformers
pipeline.set_params(
    mapper__colC__standardscaler__with_mean=True,
    mapper__colC__functiontransformer__func=np.log1p
)

# 5. grid search with parameters
param_grid = dict(
    mapper__colA__standardscaler__with_mean=[True, False],
    mapper__colB__standardscaler__with_std=[True, False],
    mapper__colC__functiontransformer__func=[np.log1p, np.exp, None]  
)
grid_search = GridSearchCV(pipeline, param_grid=param_grid)
grid_search.fit(X, y)
```

We still need to add more tests and think about possible edge cases. For example, I am not sure how to handle this case:
```python
from sklearn.pipeline import Pipeline
from sklearn.feature_selection import SelectKBest, chi2
mapper_fs = DataFrameMapper([(['children','salary'], SelectKBest(chi2, k=1))])
pipeline = Pipeline([
    ('mapper', mapper_fs),
    ('classifier', SVC(kernel='linear'))
])
# how to handle transformers with several columns?
pipeline.set_params(...)
```

Also, I think that the current implementation of `set_params` could be revised/optimized, and we can handle `get_params` and `set_params` for cases when all the transformed columns have only a single transformer using `Pipeline` class instead of writing a custom code.

Would be glad to know your thoughts and proposals to finalize the PR and make the `DataFrameMapper` grid-search ready.