### PR TITLE
Enable None sentinel for columns

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -404,6 +404,13 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                 index=index)
             # preserve types
             for col, dtype in zip(self.transformed_names_, dtypes):
+                # this ensures that int types with null values are
+                # correctly cast to float
+                if ((np.issubdtype(df_out[col].values.dtype, np.floating) and
+                     np.issubdtype(dtype, np.integer)) and
+                        not np.isfinite(df_out[col].values).all()):
+                    dtype = np.float64
+
                 df_out[col] = df_out[col].astype(dtype)
             return df_out
         else:

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -257,6 +257,20 @@ def test_complex_df(complex_dataframe):
         assert len(transformed[c]) == len(df[c])
 
 
+def test_none_all_col_sentinel(complex_dataframe):
+    """
+    Get a dataframe from a complex mapped dataframe returning all cols
+     without spec.
+    """
+    df = complex_dataframe
+    mapper = DataFrameMapper([(None, None)], df_out=True)
+    transformed = mapper.fit_transform(df)
+    print(transformed)
+    assert len(transformed) == len(complex_dataframe)
+    for c in df.columns:
+        assert len(transformed[c]) == len(df[c])
+
+
 def test_numeric_column_names(complex_dataframe):
     """
     Get a dataframe from a complex mapped dataframe with numeric column names


### PR DESCRIPTION
There is a None sentinel for transformers, but not columns. Having a None sentinel for the columns allows a set of transformers to act on all columns of the incoming dataframe. 

None sentinel for columns is important, because sometimes we don't know the columns of the dataframe. For instance, if DataFrameMapper is embedded in a long sklearn Pipeline that may have added many columns to the original dataframe, it's hard to know exact column names in the dataframe that comes in (but we may want to apply some transfomrers to all columns).

This feature also bridges the gap to make DataFrameMapper a fully-fledged PandasFeatureUnion. - something that has been requested multiple times in Issue #62 , #64 , and #69 .