### PR TITLE
Add explicit 'drop' for a column in DataframeMapper, #208

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,32 @@ attribute.
 
 Note this does not work together with the ``default=True`` or ``sparse=True`` arguments to the mapper.
 
+Dropping columns explictly
+*******************************
+
+Sometimes it is required to drop a specific column/ list of columns.
+For this purpose, ``drop_cols``  argument for ``DataFrameMapper`` can be used.
+Default value is ``None``
+
+    >>> mapper_df = DataFrameMapper([
+    ...     ('pet', sklearn.preprocessing.LabelBinarizer()),
+    ...     (['children'], sklearn.preprocessing.StandardScaler())
+    ... ], drop_cols=['salary'])
+
+Now running ``fit_transform`` will run transformations on 'pet' and 'children' and drop 'salary' column:
+
+   >>> np.round(mapper_df.fit_transform(data.copy()), 1)
+   array([[ 1. ,  0. ,  0. ,  0.2],
+          [ 0. ,  1. ,  0. ,  1.9],
+          [ 0. ,  1. ,  0. , -0.6],
+          [ 0. ,  0. ,  1. , -0.6],
+          [ 1. ,  0. ,  0. , -1.5],
+          [ 0. ,  1. ,  0. , -0.6],
+          [ 1. ,  0. ,  0. ,  1. ],
+          [ 0. ,  0. ,  1. ,  0.2]])
+
+Transformations may require multiple input columns. In these
+
 Transform Multiple Columns
 **************************
 
@@ -395,7 +421,7 @@ The stacking of the sparse features is done without ever densifying them.
 
 
 Using ``NumericalTransformer``
-****************************
+***********************************
 
 While you can use ``FunctionTransformation`` to generate arbitrary transformers, it can present serialization issues
 when pickling. Use ``NumericalTransformer`` instead, which takes the function name as a string parameter and hence
@@ -430,6 +456,8 @@ Changelog
 * Added ``NumericalTransformer`` for common numerical transformations. Currently it implements log and log1p
   transformation.
 * Added prefix and suffix options. See examples above. These are usually helpful when using gen_features.
+* Added ``drop_cols`` argument to DataframeMapper. This can be used to explicitly drop columns
+
 
 
 1.8.0 (2018-12-01)
@@ -543,3 +571,4 @@ Other contributors:
 * Timothy Sweetser (@hacktuarial)
 * Vitaley Zaretskey (@vzaretsk)
 * Zac Stewart (@zacstewart)
+* Parul Singh (@paro1234)

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -71,7 +71,8 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                     The first element is the pandas column selector. This can
                     be a string (for one column) or a list of strings.
                     The second element is an object that supports
-                    sklearn's transform interface, or a list of such objects or a keyword 'drop'
+                    sklearn's transform interface, or a list of such objects
+                    or a keyword 'drop'
                     The third element is optional and, if present, must be
                     a dictionary with the options to apply to the
                     transformation. Example: {'alias': 'day_of_week'}
@@ -134,7 +135,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                     else:
                         drop_columns.add(col)
             return drop_columns
-        except:
+        except TypeError:
             return None
 
     @staticmethod
@@ -148,7 +149,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
                 if feature[1] != 'drop':
                     f.append(feature)
             return f
-        except:
+        except TypeError:
             return None
 
     @property
@@ -176,7 +177,8 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         """
         X_columns = list(X.columns)
         return [column for column in X_columns if
-                column not in self._selected_columns and column not in self._drop_columns]
+                column not in self._selected_columns
+                and column not in self._drop_columns]
 
     def __setstate__(self, state):
         # compatibility for older versions of sklearn-pandas

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -663,11 +663,12 @@ def test_unselected_columns():
 def test_drop_columns():
     """
     drop_columns returns a list of the columns not appearing in the
-    features of the mapper but present in the given dataframe, having keyword 'drop'
+    features of the mapper but present in the given dataframe,
+    having keyword 'drop'
     """
     mapper = DataFrameMapper([
         ('a', None),
-        ('b','drop'),
+        ('b', 'drop'),
         ('c', None)
     ])
     assert mapper._drop_columns == {'b'}
@@ -681,7 +682,7 @@ def test_selected_columns_with_drop_and_default_none():
     df = pd.DataFrame({'a': [1], 'b': [2], 'c': [3]})
     mapper = DataFrameMapper([
         ('a', None),
-        ('c','drop')
+        ('c', 'drop')
     ], default=None)
     transformed = mapper.fit_transform(df)
     assert transformed.shape == (1, 2)
@@ -699,7 +700,6 @@ def test_default_false():
 
     transformed = mapper.fit_transform(df)
     assert transformed.shape == (3, 1)
-
 
 
 def test_default_none():

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -660,6 +660,34 @@ def test_unselected_columns():
     assert 'c' in mapper._unselected_columns(df)
 
 
+def test_drop_columns():
+    """
+    drop_columns returns a list of the columns not appearing in the
+    features of the mapper but present in the given dataframe, having keyword 'drop'
+    """
+    mapper = DataFrameMapper([
+        ('a', None),
+        ('b','drop'),
+        ('c', None)
+    ])
+    assert mapper._drop_columns == {'b'}
+
+
+def test_selected_columns_with_drop_and_default_none():
+    """
+    selected_columns returns a set of the columns appearing in the features
+    of the mapper.
+    """
+    df = pd.DataFrame({'a': [1], 'b': [2], 'c': [3]})
+    mapper = DataFrameMapper([
+        ('a', None),
+        ('c','drop')
+    ], default=None)
+    transformed = mapper.fit_transform(df)
+    assert transformed.shape == (1, 2)
+    assert mapper.transformed_names_ == ['a', 'b']
+
+
 def test_default_false():
     """
     If default=False, non explicitly selected columns are discarded.
@@ -671,6 +699,7 @@ def test_default_false():
 
     transformed = mapper.fit_transform(df)
     assert transformed.shape == (3, 1)
+
 
 
 def test_default_none():

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -649,7 +649,7 @@ def test_selected_columns():
 
 def test_unselected_columns():
     """
-    selected_columns returns a list of the columns not appearing in the
+    unselected_columns returns a list of the columns not appearing in the
     features of the mapper but present in the given dataframe.
     """
     df = pd.DataFrame({'a': [1], 'b': [2], 'c': [3]})
@@ -660,32 +660,32 @@ def test_unselected_columns():
     assert 'c' in mapper._unselected_columns(df)
 
 
-def test_drop_columns():
+def test_drop_and_default_false():
     """
-    drop_columns returns a list of the columns not appearing in the
-    features of the mapper but present in the given dataframe,
-    having keyword 'drop'
-    """
-    mapper = DataFrameMapper([
-        ('a', None),
-        ('b', 'drop'),
-        ('c', None)
-    ])
-    assert mapper._drop_columns == {'b'}
-
-
-def test_selected_columns_with_drop_and_default_none():
-    """
-    selected_columns returns a set of the columns appearing in the features
-    of the mapper.
+    If default=False, non explicitly selected columns and drop columns
+    are discarded.
     """
     df = pd.DataFrame({'a': [1], 'b': [2], 'c': [3]})
     mapper = DataFrameMapper([
-        ('a', None),
-        ('c', 'drop')
-    ], default=None)
+            ('a', None)
+        ], drop_cols=['c'])
     transformed = mapper.fit_transform(df)
-    assert transformed.shape == (1, 2)
+    assert transformed.shape == (1, 1)
+    assert mapper.transformed_names_ == ['a']
+
+
+def test_drop_and_default_none():
+    """
+    If default=None, drop columns are discarded and
+    remaining non explicitly selected columns are passed through untransformed
+    """
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 5, 7]})
+    mapper = DataFrameMapper([
+        ('a', None)
+    ], drop_cols=['c'], default=None)
+
+    transformed = mapper.fit_transform(df)
+    assert transformed.shape == (3, 2)
     assert mapper.transformed_names_ == ['a', 'b']
 
 


### PR DESCRIPTION
Hello @ragrawal 
I have added the relevant code here along with tests. 
I am finding issue in passing three tests, all failing with the same error. It would be great if you help me how to fix this. 
Details : 
Error : `E               RuntimeError: Cannot clone object DataFrameMapper(features=[('petal length (cm)', None),
E                                         ('petal width (cm)', None),
E                                         ('sepal length (cm)', None),
E                                         ('sepal width (cm)', None)]), as the constructor either does not set or modifies parameter features`

Similar to this issue : https://github.com/scikit-learn/scikit-learn/issues/15722

Tests failing : test_with_iris_dataframe, test_with_car_dataframe, test_direct_cross_validation

Since this is my first contribution to an open source project, please feel free to put your comments and suggestions

Thanks

