### PR TITLE
added deprecation warning

### DIFF
--- a/sklearn_pandas/transformers.py
+++ b/sklearn_pandas/transformers.py
@@ -33,7 +33,7 @@ class NumericalTransformer(TransformerMixin):
         warnings.warn("""
             NumericalTransformer is deprecated. Please write your own 
             transformer using Sklearn.base.TransformerMixin class
-            """, warnings.DeprecationWarning)
+            """, DeprecationWarning)
         assert func in self.SUPPORTED_FUNCTIONS, \
             f"Only following func are supported: {self.SUPPORTED_FUNCTIONS}"
         super(NumericalTransformer, self).__init__()

--- a/sklearn_pandas/transformers.py
+++ b/sklearn_pandas/transformers.py
@@ -3,6 +3,7 @@ import pandas as pd
 from sklearn.base import TransformerMixin
 import warnings
 
+
 def _get_mask(X, value):
     """
     Compute the boolean mask X == missing_values.
@@ -30,8 +31,9 @@ class NumericalTransformer(TransformerMixin):
                 in SUPPORTED_FUNCTIONS variable. Throws assertion error if the
                 not supported.
         """
+
         warnings.warn("""
-            NumericalTransformer is deprecated. Please write your own 
+            NumericalTransformer is deprecated. Please write your own
             transformer using Sklearn.base.TransformerMixin class
             """, DeprecationWarning)
         assert func in self.SUPPORTED_FUNCTIONS, \

--- a/sklearn_pandas/transformers.py
+++ b/sklearn_pandas/transformers.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin
-
+import warnings
 
 def _get_mask(X, value):
     """
@@ -30,6 +30,10 @@ class NumericalTransformer(TransformerMixin):
                 in SUPPORTED_FUNCTIONS variable. Throws assertion error if the
                 not supported.
         """
+        warnings.warn("""
+            NumericalTransformer is deprecated. Please write your own 
+            transformer using Sklearn.base.TransformerMixin class
+            """, warnings.DeprecationWarning)
         assert func in self.SUPPORTED_FUNCTIONS, \
             f"Only following func are supported: {self.SUPPORTED_FUNCTIONS}"
         super(NumericalTransformer, self).__init__()


### PR DESCRIPTION
It doesn't make sense for sklearn_pandas to maintain the numerical transformer as a library as this can bring a lot of additional dependencies. Instead, it makes sense that users implement their own transformers. 