### PR TITLE
Allow specifying columns with a filter function

### DIFF
--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -186,8 +186,8 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
 
         X       a Pandas dataframe; the table to select columns from
         cols    a string or list of strings representing the columns to select.
-                It can also be a callable that returns True or False, i.e. compatible
-                with the built-in filter function.
+                It can also be a callable that returns True or False, i.e.
+                compatible with the built-in filter function.
 
         Returns a numpy array with the data from the selected columns
         """

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -185,11 +185,15 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         Get a subset of columns from the given table X.
 
         X       a Pandas dataframe; the table to select columns from
-        cols    a string or list of strings representing the columns
-                to select
+        cols    a string or list of strings representing the columns to select.
+                It can also be a callable that returns True or False, i.e. compatible
+                with the built-in filter function.
 
         Returns a numpy array with the data from the selected columns
         """
+        if callable(cols):
+            cols = filter(cols, X.columns)
+
         if isinstance(cols, string_types):
             return_vector = True
             cols = [cols]


### PR DESCRIPTION
A use case for this would be when you do not have full knowledge of all the columns in the dataframe.

In the current implementation, I cannot do following, because `df` is not defined. `mapper` could be used in a middle step of a pipeline where a previous step produces a variable number of columns starting with `"special_"`

```
mapper = DataFrameMapper(
    [
        (
            [col for col in df.columns if col.startswith("special_")],
            SomeTransformer(),
        )
    ]
)
```

In my implementation, I could do this:

```
mapper = DataFrameMapper(
    [
        (
            lambda x: x.startswith("special_"),
            SomeTransformer(),
        )
    ]
)
```

I don't mean to hijack #239, but I thought this would be a good start.

What do you think?